### PR TITLE
Adding-rolling-sum-logic

### DIFF
--- a/lib/asset_manager/projections/deposit_transaction.ex
+++ b/lib/asset_manager/projections/deposit_transaction.ex
@@ -4,8 +4,8 @@ defmodule AssetManager.Projections.DepositTransaction do
   @primary_key false
   schema "deposit_transactions" do
     field :request_id, :string
-    field :amount, :decimal
-    field :created_at, :utc_datetime_usec
+    field :amount, :decimal, primary_key: true
+    field :created_at, :utc_datetime_usec, primary_key: true
 
     timestamps(type: :utc_datetime_usec)
   end

--- a/lib/asset_manager/projectors/transaction_projector.ex
+++ b/lib/asset_manager/projectors/transaction_projector.ex
@@ -4,16 +4,32 @@ defmodule AssetManager.Projectors.TransactionProjector do
     repo: AssetManager.Repo,
     name: "TransactionProjector"
 
-  alias Ecto.Multi
+  alias Ecto.{Changeset, Multi}
+  alias AssetManager.Repo
   alias AssetManager.ServiceAccounts.Events.Deposited
   alias AssetManager.Projections.DepositTransaction
 
   project(%Deposited{} = evt, _, fn multi ->
     multi
-    |> Multi.insert(:deposit_transaction, %DepositTransaction{
-      request_id: evt.request_id,
-      amount: evt.amount,
-      created_at: evt.created_at
-    })
+    |> Multi.run(:all, fn _repo, _changes ->
+      all =
+        Repo.get_by(DepositTransaction,
+          created_at: evt.created_at
+        ) ||
+          %DepositTransaction{
+            request_id: evt.request_id,
+            amount: Decimal.new(0),
+            created_at: evt.created_at
+          }
+
+      {:ok, all}
+    end)
+    |> Multi.insert_or_update(:all_updated, fn %{all: %DepositTransaction{} = all} ->
+      all
+      |> Changeset.change(
+        amount: Decimal.add(all.amount, evt.amount),
+        created_at: evt.created_at
+      )
+    end)
   end)
 end

--- a/lib/asset_manager/service_accounts.ex
+++ b/lib/asset_manager/service_accounts.ex
@@ -29,8 +29,7 @@ defmodule AssetManager.ServiceAccounts do
     DepositTransaction
     |> where([b], b.created_at >= ^start_datetime and b.created_at <= ^end_datetime)
     |> order_by([b], asc: b.created_at)
-    |> select([b], %{hour: b.created_at, amount: sum(b.amount)})
-    |> group_by([b], b.created_at)
+    |> select([b], %{hour: b.created_at, amount: b.amount})
     |> Repo.all()
   end
 

--- a/priv/repo/migrations/20230408064908_add_transaction_projector.exs
+++ b/priv/repo/migrations/20230408064908_add_transaction_projector.exs
@@ -3,9 +3,9 @@ defmodule AssetManager.Repo.Migrations.AddTransactionProjector do
 
   def change do
     create table("deposit_transactions", primary_key: false) do
-      add :request_id, :string, primary_key: true
-      add :created_at, :utc_datetime_usec
-      add :amount, :decimal
+      add :created_at, :utc_datetime_usec, primary_key: true
+      add :request_id, :string
+      add :amount, :decimal, primary_key: true
 
       timestamps(type: :utc_datetime_usec)
     end


### PR DESCRIPTION
Note:
It just come to my mind that there can be one more way to return the sum every hour from the write model.
So, I have also raised a small PR (Pull Request) for rolling sum logic. If this app is facing huge amount of traffic, then while inserting the data in the write model,
we can firstly fetch the existing amount and update the entry of amount by doing the sum of existing amount and upcoming new amount for that hour.
It will be more efficient. It's just one more way to make it bit faster even though I already have index on created_at column.
 
 
<img width="1028" alt="Screen Shot 2566-04-13 at 16 17 09" src="https://user-images.githubusercontent.com/87823879/231724073-a0cc4293-9e26-48b8-8155-cc654f0b5d01.png">
<img width="1225" alt="Screen Shot 2566-04-13 at 16 17 31" src="https://user-images.githubusercontent.com/87823879/231724100-d14b4bfb-3446-4423-bc09-1f19ac66836e.png">
<img width="939" alt="Screen Shot 2566-04-13 at 16 17 48" src="https://user-images.githubusercontent.com/87823879/231724125-180289ba-79e8-4d9c-95c2-4efa554ede8b.png">
<img width="915" alt="Screen Shot 2566-04-13 at 16 18 26" src="https://user-images.githubusercontent.com/87823879/231724143-cba5354d-1914-455f-a9d8-0c2405306ad9.png">
